### PR TITLE
Updated to run on the latest Rust with stabilised futures and tokio 1.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ tokio = { version = "1.6.0", features = ["rt-multi-thread"] }
 tokio-stream = "~0.1.6"
 
 [dev-dependencies]
-tokio = { version = "1.6.0", features = ["rt-multi-thread", "test-util", "macros"] }
+tokio = { version = "1.6.0", features = ["rt-multi-thread", "test-util", "macros", "time"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,18 @@
 [package]
 name = "tokio-scoped"
-version = "0.1.0"
-authors = ["Jason Boatman <jasonaboatman@gmail.com>"]
+version = "0.2.0"
+authors = ["Jason Boatman <jasonaboatman@gmail.com>", "Nick Webster <nick@nick.geek.nz>"]
 description = "Scoped Runtime for tokio"
 homepage = "https://github.com/Snnappie/tokio-scoped"
 repository = "https://github.com/Snnappie/tokio-scoped"
 readme = "README.md"
 keywords = ["scope", "tokio", "futures"]
 license = "MIT"
+edition = "2018"
 
 [dependencies]
-tokio = "0.1"
-futures = "0.1"
+tokio = { version = "1.6.0", features = ["rt-multi-thread"] }
+futures = "~0.3.15"
+
+[dev-dependencies]
+tokio = { version = "1.6.0", features = ["rt-multi-thread", "test-util", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 tokio = { version = "1.6.0", features = ["rt-multi-thread"] }
-futures = "~0.3.15"
+tokio-stream = "~0.1.6"
 
 [dev-dependencies]
 tokio = { version = "1.6.0", features = ["rt-multi-thread", "test-util", "macros"] }

--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
 # tokio-scoped
-tokio-scoped provides a `scope` function and `ScopedRuntime` struct inspired by [crossbeam](https://docs.rs/crossbeam/0.4.1/crossbeam/fn.scope.html)
+tokio-scoped provides a `scope` function and `ScopedRuntime` struct inspired by [crossbeam](https://docs.rs/crossbeam/0.8.0/crossbeam/fn.scope.html)
 but for the `tokio` Runtime. A scope allows one to spawn futures which do not have a `'static` lifetime
 by ensuring each future spawned in the scope completes before the scope exits.
 
 ## Example
 
 ```rust
-extern crate tokio_scoped;
-extern crate futures;
-use futures::lazy;
+use futures::future::lazy;
 
-let mut v = String::from("Hello");
-tokio_scoped::scope(|scope| {
-    // Use the scope to spawn the future.
-    scope.spawn(lazy(|| {
-        v.push('!');
-        Ok(())
-    }));
-});
-// The scope won't exit until all spawned futures are complete.
-assert_eq!(v.as_str(), "Hello!");
+#[tokio::main]
+async fn main() {
+    let mut v = String::from("Hello");
+    tokio_scoped::scope(|scope| {
+        // Use the scope to spawn the future.
+        scope.spawn(lazy(|_| {
+            v.push('!');
+        }));
+    });
+    // The scope won't exit until all spawned futures are complete.
+    assert_eq!(v.as_str(), "Hello!");
+}
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,19 @@
 # tokio-scoped
-tokio-scoped provides a `scope` function and `ScopedRuntime` struct inspired by [crossbeam](https://docs.rs/crossbeam/0.8.0/crossbeam/fn.scope.html)
-but for the `tokio` Runtime. A scope allows one to spawn futures which do not have a `'static` lifetime
+tokio-scoped provides a `scope` function inspired by [crossbeam](https://docs.rs/crossbeam/0.8.0/crossbeam/fn.scope.html)
+but for the [`tokio`](https://tokio.rs/) Runtime. A scope allows one to spawn futures which do not have a `'static` lifetime
 by ensuring each future spawned in the scope completes before the scope exits.
 
 ## Example
 
 ```rust
-use futures::future::lazy;
-
 #[tokio::main]
 async fn main() {
     let mut v = String::from("Hello");
     tokio_scoped::scope(|scope| {
         // Use the scope to spawn the future.
-        scope.spawn(lazy(|_| {
+        scope.spawn(async {
             v.push('!');
-        }));
+        });
     });
     // The scope won't exit until all spawned futures are complete.
     assert_eq!(v.as_str(), "Hello!");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,112 +7,104 @@
 //!
 //! # Example
 //! ```
-//! # extern crate tokio_scoped;
-//! # extern crate futures;
-//! # use futures::lazy;
+//! use futures::future::lazy;
 //!
-//! let mut v = String::from("Hello");
-//! tokio_scoped::scope(|scope| {
-//!     // Use the scope to spawn the future.
-//!     scope.spawn(lazy(|| {
-//!         v.push('!');
-//!         Ok(())
-//!     }));
-//! });
-//! // The scope won't exit until all spawned futures are complete.
-//! assert_eq!(v.as_str(), "Hello!");
+//! #[tokio::main]
+//! async fn main() {
+//!     let mut v = String::from("Hello");
+//!     tokio_scoped::scope(|scope| {
+//!         // Use the scope to spawn the future.
+//!         scope.spawn(lazy(|_| {
+//!             v.push('!');
+//!         }));
+//!     });
+//!     // The scope won't exit until all spawned futures are complete.
+//!     assert_eq!(v.as_str(), "Hello!");
+//! }
 //! ```
 //!
 //! See also [`crossbeam::scope`]
 //!
 //! [`tokio`]: https://tokio.rs/
 //! [`crossbeam::scope`]: https://docs.rs/crossbeam/0.4.1/crossbeam/fn.scope.html
-extern crate futures;
-extern crate tokio;
+use futures;
+use tokio;
 
-use futures::sync::mpsc;
-use futures::{Future, Stream};
+use futures::channel::mpsc;
+use futures::{FutureExt, StreamExt};
+use std::future::Future;
 use std::marker::PhantomData;
 use std::mem::ManuallyDrop;
 use std::ops::Deref;
-use tokio::runtime::TaskExecutor;
+use tokio::runtime::Runtime;
+use tokio::runtime::Handle;
+use std::task::{Context, Poll};
+use std::pin::Pin;
+use std::fmt::Debug;
+use std::borrow::Cow;
 
-/// Creates a [`ScopedRuntime`] and calls the `scope` method with `f` on it.
+/// Creates a [`Scope`] using the current tokio runtime and calls the `scope` method with the
+/// provided future
 ///
 /// # Example
 /// ```
-/// # extern crate tokio_scoped;
-/// # extern crate futures;
-/// # use futures::lazy;
+/// use futures::future::lazy;
 ///
-/// let mut v = String::from("Hello");
-/// tokio_scoped::scope(|scope| {
-///     // Use the scope to spawn the future.
-///     scope.spawn(lazy(|| {
-///         v.push('!');
-///         Ok(())
-///     }));
-/// });
-/// // The scope won't exit until all spawned futures are complete.
-/// assert_eq!(v.as_str(), "Hello!");
+/// #[tokio::main]
+/// async fn main() {
+///     let mut v = String::from("Hello");
+///     tokio_scoped::scope(|scope| {
+///         // Use the scope to spawn the future.
+///         scope.spawn(lazy(|_| {
+///             v.push('!');
+///         }));
+///     });
+///     // The scope won't exit until all spawned futures are complete.
+///     assert_eq!(v.as_str(), "Hello!");
+/// }
 /// ```
 pub fn scope<'a, F, R>(f: F) -> R
 where
     F: FnOnce(&mut Scope<'a>) -> R,
 {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    let mut scope = Scope::new(rt.executor());
+    let mut scope = Scope::new(Cow::Owned(Handle::current()));
     f(&mut scope)
 }
 
-/// Borrows the Runtime to construct a `ScopeBuilder` which can be used to create a scope.
+/// Borrows a `Handle` to the tokio `Runtime` to construct a [`ScopeBuilder`] which can be used to
+/// create a scope.
 ///
 /// # Example
 /// ```
-/// # extern crate tokio_scoped;
-/// # extern crate futures;
-/// # extern crate tokio;
-/// # use futures::lazy;
+/// use futures::future::lazy;
 ///
 /// let mut v = String::from("Hello");
 /// let rt = tokio::runtime::Runtime::new().unwrap();
-/// tokio_scoped::scoped(&rt).scope(|scope| {
+/// tokio_scoped::scoped(rt.handle()).scope(|scope| {
 ///     // Use the scope to spawn the future.
-///     scope.spawn(lazy(|| {
+///     scope.spawn(lazy(|_| {
 ///         v.push('!');
-///         Ok(())
 ///     }));
 /// });
 /// // The scope won't exit until all spawned futures are complete.
 /// assert_eq!(v.as_str(), "Hello!");
 /// ```
-pub fn scoped(rt: &tokio::runtime::Runtime) -> ScopeBuilder<'_> {
-    ScopeBuilder::from_runtime(rt)
+pub fn scoped(tokio_handle: &Handle) -> ScopeBuilder<'_> {
+    ScopeBuilder { handle: tokio_handle }
 }
 
-/// Wrapper type around a tokio Runtime which can be used to create `Scope`s. This type takes
-/// ownership of the Runtime. For an alternative approach that
-///
-/// See also the [`scope`] function.
-///
-/// [`scope`]: /tokio-scoped/fn.scope.html
-#[derive(Debug)]
-pub struct ScopedRuntime {
-    rt: tokio::runtime::Runtime,
-}
-
-/// Struct used to build scopes from a borrowed Runtime. Generally users should use the [`scoped`]
+/// Struct used to build scopes from a borrowed `Handle`. Generally users should use the [`scoped`]
 /// function instead of building `ScopeBuilder` instances directly.
 ///
 /// [`scoped`]: /tokio-scoped/fn.scoped.html
 #[derive(Debug)]
 pub struct ScopeBuilder<'a> {
-    rt: &'a tokio::runtime::Runtime,
+    handle: &'a Handle,
 }
 
 #[derive(Debug)]
 pub struct Scope<'a> {
-    exec: TaskExecutor,
+    handle: Cow<'a, Handle>,
     send: ManuallyDrop<mpsc::Sender<()>>,
     // When the `Scope` is dropped, we wait on this receiver to close. No messages are sent through
     // the receiver, however, the `Sender` objects get cloned into each spawned future (see
@@ -122,10 +114,10 @@ pub struct Scope<'a> {
 }
 
 impl<'a> Scope<'a> {
-    fn new(exec: TaskExecutor) -> Scope<'a> {
+    fn new<'b: 'a>(handle: Cow<'b, Handle>) -> Scope<'a> {
         let (s, r) = mpsc::channel(0);
         Scope {
-            exec,
+            handle,
             send: ManuallyDrop::new(s),
             recv: Some(r),
             _marker: PhantomData,
@@ -133,102 +125,89 @@ impl<'a> Scope<'a> {
     }
 }
 
-impl ScopedRuntime {
-    pub fn new(rt: tokio::runtime::Runtime) -> Self {
-        ScopedRuntime { rt }
-    }
-
-    /// Creates a scope bound by the lifetime of `self` that can be used to spawn scoped futures.
-    pub fn scope<'a, F, R>(&'a self, f: F) -> R
-    where
-        F: FnOnce(&mut Scope<'a>) -> R,
-    {
-        let mut scope = Scope::new(self.rt.executor());
-        f(&mut scope)
-    }
-
-    /// Consumes the `ScopedRuntime` and returns the inner [`Runtime`] variable.
-    ///
-    /// [`Runtime`]: https://docs.rs/tokio/0.1.8/tokio/runtime/struct.Runtime.html
-    pub fn into_inner(self) -> tokio::runtime::Runtime {
-        self.rt
-    }
-}
-
 impl<'a> ScopeBuilder<'a> {
     pub fn from_runtime(rt: &'a tokio::runtime::Runtime) -> ScopeBuilder<'a> {
-        ScopeBuilder { rt }
+        ScopeBuilder { handle: rt.handle() }
     }
 
     pub fn scope<F, R>(&self, f: F) -> R
     where
         F: FnOnce(&mut Scope<'a>) -> R,
     {
-        let mut scope = Scope::new(self.rt.executor());
+        let mut scope = Scope::new(Cow::Borrowed(self.handle));
         f(&mut scope)
     }
 }
 
 struct ScopedFuture {
-    f: Box<Future<Item = (), Error = ()> + Send + 'static>,
+    f: Pin<Box<dyn Future<Output = ()> + Send + 'static>>,
     _marker: mpsc::Sender<()>,
 }
 
 impl Future for ScopedFuture {
-    type Item = ();
-    type Error = ();
-    fn poll(&mut self) -> futures::Poll<(), ()> {
-        self.f.poll()
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let inner_future = &mut self.f;
+        let future_ref = Pin::as_mut(inner_future);
+        future_ref.poll(cx)
     }
 }
 
 impl<'a> Scope<'a> {
     fn scoped_future<'s, F>(&'s self, f: F) -> ScopedFuture
     where
-        F: Future<Item = (), Error = ()> + Send + 'a,
+        F: Future<Output = ()> + Send + 'a,
         'a: 's,
     {
-        let boxed: Box<Future<Item = (), Error = ()> + Send + 'a> = Box::new(f);
+        let boxed: Pin<Box<dyn Future<Output = ()> + Send + 'a>> = Box::pin(f);
         // This transmute should be safe, as we use the `ScopedFuture` abstraction to prevent the
         // scope from exiting until every spawned `ScopedFuture` object is dropped, signifying that
         // they have completed their execution.
-        let boxed: Box<Future<Item = (), Error = ()> + Send + 'static> =
+        let boxed: Pin<Box<dyn Future<Output = ()> + Send + 'static>> =
             unsafe { std::mem::transmute(boxed) };
+
         ScopedFuture {
             f: boxed,
             _marker: self.send.deref().clone(),
         }
     }
 
-    /// Spawn the received future on the [`ScopedRuntime`] which was used to create `self`.
-    ///
-    /// [`ScopedRuntime`]: /tokio-scoped/struct.ScopedRuntime.html
+    /// Spawn the provided future on the `Handle` to the tokio `Runtime`.
     pub fn spawn<'s, F>(&'s mut self, future: F) -> &mut Self
     where
-        F: Future<Item = (), Error = ()> + Send + 'a,
+        F: Future<Output = ()> + Send + 'a,
         'a: 's,
     {
         let scoped_f = self.scoped_future(future);
-        self.exec.spawn(scoped_f);
+        self.handle.spawn(scoped_f);
         self
     }
 
     /// Blocks the "current thread" of the runtime until `future` resolves. Other spawned futures
-    /// can make progress while this future is running.
-    pub fn block_on<'s, R, E, F>(&'s mut self, future: F) -> Result<R, E>
+    /// that have been allocated to different threads can make progress while this future is running.
+    pub fn block_on<'s, R, F>(&'s mut self, future: F) -> R
     where
-        F: Future<Item = R, Error = E> + Send + 'a,
-        R: Send + 'a,
-        E: Send + 'a,
+        F: Future<Output = R> + Send + 'a,
+        R: Send + Debug + 'a,
         'a: 's,
     {
-        let (tx, rx) = futures::sync::oneshot::channel();
-        let future = future.then(move |r| tx.send(r).map_err(|_| unreachable!()));
-        let boxed: Box<Future<Item = (), Error = ()> + Send + 'a> = Box::new(future);
-        let boxed: Box<Future<Item = (), Error = ()> + Send + 'static> =
+        let (tx, rx) = futures::channel::oneshot::channel();
+        let future = future.then(move |r| async {
+            tx.send(r).unwrap()
+        });
+        let boxed: Pin<Box<dyn Future<Output = ()> + Send + 'a>> = Box::pin(future);
+        let boxed: Pin<Box<dyn Future<Output = ()> + Send + 'static>> =
             unsafe { std::mem::transmute(boxed) };
-        self.exec.spawn(boxed);
-        rx.wait().unwrap()
+
+        self.handle.spawn(boxed);
+
+        {
+            let handle = (&*self.handle).clone();
+            tokio::task::block_in_place(move || {
+                handle.block_on(rx)
+            }).unwrap()
+        }
     }
 
     /// Creates an `inner` scope which can access variables created within the outer scope.
@@ -237,13 +216,13 @@ impl<'a> Scope<'a> {
         F: FnOnce(&mut Scope<'inner>) -> R,
         'a: 'inner,
     {
-        let mut scope = Scope::new(self.exec.clone());
+        let mut scope = Scope::new(self.handle.clone());
         f(&mut scope)
     }
 
-    /// Get a `TaskExecutor` to the underlying `Runtime` instance.
-    pub fn executor(&self) -> TaskExecutor {
-        self.exec.clone()
+    /// Get a `Handle` to the underlying `Runtime` instance.
+    pub fn handle(&self) -> Handle {
+        (&*self.handle).clone()
     }
 }
 
@@ -253,8 +232,8 @@ impl<'a> Drop for Scope<'a> {
             ManuallyDrop::drop(&mut self.send);
         }
 
-        let recv = self.recv.take().unwrap();
-        let n = recv.wait().next();
+        let mut recv = self.recv.take().unwrap();
+        let n = futures::executor::block_on(recv.next());
         assert_eq!(n, None);
     }
 }
@@ -262,31 +241,30 @@ impl<'a> Drop for Scope<'a> {
 #[cfg(test)]
 mod testing {
     use super::*;
-    use futures::lazy;
+    use futures::future::lazy;
     use std::{thread, time::Duration};
     use tokio;
-    fn make_runtime() -> ScopedRuntime {
-        let rt = tokio::runtime::Runtime::new().expect("Failed to construct Runtime");
-        ScopedRuntime::new(rt)
+
+    fn make_runtime() -> Runtime {
+        Runtime::new().expect("Failed to construct Runtime")
     }
 
     #[test]
     fn basic_test() {
-        let scoped = make_runtime();
+        let rt = make_runtime();
+        let scoped = scoped(rt.handle());
         scoped.scope(|scope| {
-            scope.spawn(lazy(|| {
-                tokio::spawn(lazy(|| {
+            scope.spawn(lazy(|_| {
+                tokio::spawn(lazy(|_| {
                     println!("Another!");
                     thread::sleep(Duration::from_millis(5000));
                     println!("Another is done sleeping");
-                    Ok(())
                 }));
 
                 println!("Sleeping a spawned future");
                 // We should be able to spawn more and also verify that they complete...
                 thread::sleep(Duration::from_millis(2000));
                 println!("Completing!");
-                Ok(())
             }));
         });
         println!("Completed");
@@ -294,37 +272,36 @@ mod testing {
 
     #[test]
     fn access_stack() {
-        let scoped = make_runtime();
+        let rt = make_runtime();
+        let scoped = scoped(rt.handle());
         // Specifically a variable that does _not_ implement Copy.
         let uncopy = String::from("Borrowed!");
         scoped.scope(|scope| {
-            scope.spawn(lazy(|| {
+            scope.spawn(lazy(|_| {
                 assert_eq!(uncopy.as_str(), "Borrowed!");
                 println!("Borrowed successfully: {}", uncopy);
-                Ok(())
             }));
         });
     }
 
     #[test]
     fn access_mut_stack() {
-        let scoped = make_runtime();
+        let rt = make_runtime();
+        let scoped = scoped(rt.handle());
         let mut uncopy = String::from("Borrowed");
         let mut uncopy2 = String::from("Borrowed");
         scoped.scope(|scope| {
-            scope.spawn(lazy(|| {
+            scope.spawn(lazy(|_| {
                 let f = scoped
-                    .scope(|scope2| scope2.block_on(lazy(|| Ok::<_, ()>(4))))
+                    .scope(|scope2| scope2.block_on(lazy(|_| Ok::<_, ()>(4))))
                     .unwrap();
                 assert_eq!(f, 4);
                 thread::sleep(Duration::from_millis(1000));
                 uncopy.push('!');
-                Ok(())
             }));
 
-            scope.spawn(lazy(|| {
+            scope.spawn(lazy(|_| {
                 uncopy2.push('f');
-                Ok(())
             }));
         });
 
@@ -332,19 +309,17 @@ mod testing {
         assert_eq!(uncopy2.as_str(), "Borrowedf");
     }
 
-    #[test]
-    fn access_mut_stack_scope_fn() {
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn access_mut_stack_scope_fn() {
         let mut uncopy = String::from("Borrowed");
         let mut uncopy2 = String::from("Borrowed");
-        ::scope(|scope| {
-            scope.spawn(lazy(|| {
+        scope(|scope| {
+            scope.spawn(lazy(|_| {
                 uncopy.push('!');
-                Ok(())
             }));
 
-            scope.spawn(lazy(|| {
+            scope.spawn(lazy(|_| {
                 uncopy2.push('f');
-                Ok(())
             }));
         });
 
@@ -354,11 +329,12 @@ mod testing {
 
     #[test]
     fn block_on_test() {
-        let scoped = make_runtime();
+        let rt = make_runtime();
+        let scoped = scoped(rt.handle());
         let mut uncopy = String::from("Borrowed");
         let captured = scoped.scope(|scope| {
             let v = scope
-                .block_on(lazy(|| {
+                .block_on(lazy(|_| {
                     uncopy.push('!');
                     Ok::<_, ()>(uncopy)
                 }))
@@ -371,13 +347,13 @@ mod testing {
 
     #[test]
     fn borrow_many_test() {
-        let scoped = make_runtime();
+        let rt = make_runtime();
+        let scoped = scoped(rt.handle());
         let mut values = vec![1, 2, 3, 4];
         scoped.scope(|scope| {
             for v in &mut values {
-                scope.spawn(lazy(move || {
+                scope.spawn(lazy(move |_| {
                     *v += 1;
-                    Ok(())
                 }));
             }
         });
@@ -387,15 +363,15 @@ mod testing {
 
     #[test]
     fn inner_scope_test() {
-        let scoped = make_runtime();
+        let rt = make_runtime();
+        let scoped = scoped(rt.handle());
         let mut values = vec![1, 2, 3, 4];
         scoped.scope(|scope| {
             let mut v2s = vec![2, 3, 4, 5];
             scope.scope(|scope2| {
-                scope2.spawn(lazy(|| {
+                scope2.spawn(lazy(|_| {
                     v2s.push(100);
                     values.push(100);
-                    Ok(())
                 }));
             });
             // The inner scope must exit before we can get here.
@@ -408,10 +384,9 @@ mod testing {
     fn borrowed_scope_test() {
         let rt = tokio::runtime::Runtime::new().unwrap();
         let mut values = vec![1, 2, 3, 4];
-        ::scoped(&rt).scope(|scope| {
-            scope.spawn(lazy(|| {
+        ScopeBuilder::from_runtime(&rt).scope(|scope| {
+            scope.spawn(lazy(|_| {
                 values.push(100);
-                Ok(())
             }));
         });
         assert_eq!(values, &[1, 2, 3, 4, 100]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,10 +259,7 @@ mod testing {
         let mut uncopy2 = String::from("Borrowed");
         scoped.scope(|scope| {
             scope.spawn(async {
-                let f = scoped
-                    .scope(|scope2| async { Ok::<_, ()>(4) })
-                    .await
-                    .unwrap();
+                let f = scoped.scope(|scope2| async { 4 }).await;
                 assert_eq!(f, 4);
                 thread::sleep(Duration::from_millis(1000));
                 uncopy.push('!');

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,18 +227,9 @@ impl<'a> Drop for Scope<'a> {
         }
 
         let recv = self.recv.take().unwrap();
-
-        let n = match Handle::try_current() {
-            Ok(handle) => tokio::task::block_in_place(move || {
-                handle.block_on(UnboundedReceiverStream::new(recv).next())
-            }),
-            Err(_) => {
-                let rt = tokio::runtime::Builder::new_current_thread()
-                    .build()
-                    .expect("Failed to build a tokio runtime");
-                rt.block_on(UnboundedReceiverStream::new(recv).next())
-            }
-        };
+        let n = tokio::task::block_in_place(move || {
+            self.handle.block_on(UnboundedReceiverStream::new(recv).next())
+        });
         assert_eq!(n, None);
     }
 }


### PR DESCRIPTION
I updated this library to work with Tokio 1.6, Rust 2018, async/await, and removed the dependency on `futures`